### PR TITLE
Minor fixes

### DIFF
--- a/src/sequence_jacobian/blocks/support/simple_displacement.py
+++ b/src/sequence_jacobian/blocks/support/simple_displacement.py
@@ -311,7 +311,7 @@ class Displace(np.ndarray):
             return self
 
     def apply(self, f, **kwargs):
-        return Displace(f(numeric_primitive(self), **kwargs), ss=f(self.ss), ss_initial=f(self.ss_initial))
+        return Displace(f(numeric_primitive(self), **kwargs), ss=f(self.ss, **kwargs), ss_initial=f(self.ss_initial, **kwargs))
 
     def __pos__(self):
         return self


### PR DESCRIPTION
Two minor fixes:
- when using `.apply()` with keyword arguments, these are not called when evaluating the steady state. I think they should be, because they are hardwired anyways
- for nonlinear irfs, the (optional) `options` dictionary are not updated with potential keyword arguments, although it seems that this is intended (via the call to `.get_options`). 

Thanks for the great package!